### PR TITLE
Avoid conflict with `font-awesome.css`

### DIFF
--- a/app/assets/stylesheets/themes/default/application.scss
+++ b/app/assets/stylesheets/themes/default/application.scss
@@ -1,8 +1,8 @@
 @import "normalize-scss/normalize.scss";
 @import "bourbon";
 @import "neat";
-@import "font-awesome-sprockets";
-@import "font-awesome";
+@import "font-awesome-sprockets.scss";
+@import "font-awesome.scss";
 
 @import "variables";
 @import "mixins";


### PR DESCRIPTION
We want to use it from `font-awesome-sass` gem, not from other gems(such as font-awesome-rails).
